### PR TITLE
require advent-of-code-data >= 2.0.0

### DIFF
--- a/aoc_wim/__init__.py
+++ b/aoc_wim/__init__.py
@@ -25,9 +25,12 @@ def plugin(year, day, data):
     old_stdout = sys.stdout
     sys.stdout = out = io.StringIO()
     try:
+        import aocd
+        aocd.data = data
         runpy.run_module(mod_name, run_name="__main__")
     finally:
         sys.stdout = old_stdout
+        del aocd.data
     lines = [x for x in out.getvalue().splitlines() if x]
     answer_a = answer_b = None
     for line in lines:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Topic :: Games/Entertainment :: Puzzle Games",
 ]
 dependencies = [
-    "advent-of-code-data >= 1.2.3",
+    "advent-of-code-data >= 2.0.0",
     "anytree",
     "bidict",
     "numpy",


### PR DESCRIPTION
Allows to run `aoc --example` to execute solver using sample input data/answers instead of full data